### PR TITLE
Fixing -Wimplicit-function-declaration msgs flagged by clang

### DIFF
--- a/antenna.c
+++ b/antenna.c
@@ -29,6 +29,8 @@
 
 #include "qrouter.h"
 #include "qconfig.h"
+#include "mask.h"
+#include "maze.h"
 #include "node.h"
 #include "lef.h"
 #include "def.h"
@@ -313,7 +315,7 @@ get_route_area_forward_fromseg(NET net, ROUTE rt, SEG nseg, int layer,
 		}
 	    }
 	    else if ((method == ANTENNA_ROUTE) && (iroute != NULL)) {
-		set_node_to_net(node, PR_SOURCE, iroute->glist[0], iroute->bbox, 0);
+		set_node_to_net(node, PR_SOURCE, &iroute->glist[0], &iroute->bbox, 0);
 	    }
 
 	    /* Walk all other routes that start or end on this node */
@@ -583,7 +585,7 @@ get_route_area_forward_fromseg(NET net, ROUTE rt, SEG nseg, int layer,
 		if (visited) visited[node->nodenum] = VISITED;
 	    }
 	    if ((method == ANTENNA_ROUTE) && (iroute != NULL)) {
-		set_node_to_net(node, PR_SOURCE, iroute->glist[0], iroute->bbox, 0);
+		set_node_to_net(node, PR_SOURCE, &iroute->glist[0], &iroute->bbox, 0);
 	    }
 	}
 	else {

--- a/qrouter.c
+++ b/qrouter.c
@@ -877,9 +877,6 @@ static int post_def_setup()
    /* want improperly defined or positioned obstruction layers to over-	*/
    /* write our node list.						*/
 
-#ifdef TCL_QROUTER
-   find_free_antenna_taps(antenna_cell);
-#endif
    expand_tap_geometry();
    clip_gate_taps();
    create_obstructions_from_gates();

--- a/qrouter.h
+++ b/qrouter.h
@@ -512,6 +512,16 @@ void   apply_drc_blocks(int, double, double);
 void   remove_top_route(NET net);
 char  *get_annotate_info(NET net, char **pinptr);
 
+void   free_glist(struct routeinfo_ *iroute);
+
+#ifdef TCL_QROUTER
+void   find_free_antenna_taps(char *antennacell);
+#endif
+
+void   resolve_antenna(char *antennacell, u_char do_fix);
+
+void   createMask(NET net, u_char slack, u_char halo);
+void   createBboxMask(NET net, u_char halo);
 
 int    read_def(char *filename);
 

--- a/tclqrouter.c
+++ b/tclqrouter.c
@@ -19,12 +19,14 @@
 #include <X11/StringDefs.h>
 
 #include "qrouter.h"
+#include "mask.h"
 #include "maze.h"
 #include "qconfig.h"
 #include "lef.h"
 #include "def.h"
 #include "graphics.h"
 #include "node.h"
+#include "output.h"
 #include "tkSimple.h"
 
 /* Global variables */


### PR DESCRIPTION
Dear Tim,

This pull request is trying to address the large number of -`Wimplicit-function-declaration` messages flagged by clang (compile run on OpenBSD).

They are not the only warnings present in the log, but missing declarations mean that the wrong types are (potentially) used for some of the calls, so they are relevant imho.

As you see, some modifications are trivial:
- `find_free_antenna_taps` declaration moved from `qrouter.c` to `qrouter.h`;
- some other functions declared in `qrouter.h`;
- `mask.h` and `output.h` included in `tclqrouter.c`.

But the inclusion of `mask.h` and `maze.h` in `antenna.c` revealed that `set_node_to_net` function was called with wrong argument types; I just changed them to the address of the pointers in order to silence the warning/error messages, but of course I don't know if this is the right/smartest thing to do (please always keep in mind that I'm not a C programmer...)

I would suggest that you make a careful review of the PR and let me know your view.

I saved a copy of the compile logs before and after patching the code; in case you need them, just let me know.

All the best

--
Alessandro De Laurenzis