### PR TITLE
Add prototypes to functions

### DIFF
--- a/def.c
+++ b/def.c
@@ -990,10 +990,7 @@ enum def_orient {DEF_NORTH, DEF_SOUTH, DEF_EAST, DEF_WEST,
 	DEF_FLIPPED_WEST};
 
 static int
-DefReadLocation(gate, f, oscale)
-    GATE gate;
-    FILE *f;
-    float oscale;
+DefReadLocation(GATE gate, FILE *f, float oscale)
 {
     int keyword;
     char *token;
@@ -1170,7 +1167,7 @@ DefReadPins(FILE *f, char *sname, float oscale, int total)
 
 		/* Get pin name */
 		token = LefNextToken(f, TRUE);
-		if (sscanf(token, "%2047s", pinname) != 1)
+		if (sscanf(token, "%1023s", pinname) != 1)
 		{
 		    LefError(DEF_ERROR, "Bad pin statement:  Need pin name\n");
 		    LefEndStatement(f);
@@ -1360,11 +1357,7 @@ enum def_vias_prop_keys {
 	DEF_VIAS_PROP_RECT = 0};
 
 static void
-DefReadVias(f, sname, oscale, total)
-    FILE *f;
-    char *sname;
-    float oscale;
-    int total;
+DefReadVias(FILE *f, char *sname, float oscale, int total)
 {
     char *token;
     char vianame[LEF_LINE_MAX];

--- a/lef.c
+++ b/lef.c
@@ -75,9 +75,8 @@ LinkedStringPtr AllowedVias = NULL;
  */
 
 int
-Lookup(str, table)
-    char *str;			/* Pointer to a string to be looked up */
-    char *(table[]);		/* Pointer to an array of string pointers
+Lookup(char *str,		/* Pointer to a string to be looked up */
+       char *(table[]))		/* Pointer to an array of string pointers
 				 * which are the valid commands.  
 				 * The end of
 				 * the table is indicated by a NULL string.
@@ -150,9 +149,7 @@ Lookup(str, table)
  */
 
 int
-LookupFull(name, table)
-    char *name;
-    char **table;
+LookupFull(char *name, char **table)
 {
     char **tp;
 
@@ -1292,10 +1289,7 @@ LefGetViaResistance(int layer, double *respervia)
  */
 
 int
-LefReadLayers(f, obstruct, lreturn)
-    FILE *f;
-    u_char obstruct;
-    int *lreturn;
+LefReadLayers(FILE *f, u_char obstruct, int *lreturn)
 {
     char *token;
     int curlayer = -1;
@@ -2007,13 +2001,7 @@ LefReadGeometry(GATE lefMacro, FILE *f, float oscale)
  */
 
 void
-LefReadPort(lefMacro, f, pinName, pinNum, pinDir, pinUse, pinArea, oscale)
-    GATE lefMacro;
-    FILE *f;
-    char *pinName;
-    int pinNum, pinDir, pinUse;
-    double pinArea;
-    float oscale;
+LefReadPort(GATE lefMacro, FILE *f, char *pinName, int pinNum, int pinDir, int pinUse, double pinArea, float oscale)
 {
     DSEG rectList, rlist;
 
@@ -2085,12 +2073,7 @@ enum lef_pin_keys {LEF_DIRECTION = 0, LEF_USE, LEF_PORT, LEF_CAPACITANCE,
 	LEF_SHAPE, LEF_NETEXPR, LEF_PIN_END};
 
 int
-LefReadPin(lefMacro, f, pinname, pinNum, oscale)
-   GATE lefMacro;
-   FILE *f;
-   char *pinname;
-   int pinNum;
-   float oscale;
+LefReadPin(GATE lefMacro, FILE *f, char *pinname, int pinNum, float oscale)
 {
     char *token;
     int keyword, subkey;
@@ -2266,10 +2249,9 @@ enum lef_macro_keys {LEF_CLASS = 0, LEF_SIZE, LEF_ORIGIN,
 	LEF_TIMING, LEF_FOREIGN, LEF_MACRO_END};
 
 void
-LefReadMacro(f, mname, oscale)
-    FILE *f;			/* LEF file being read	*/
-    char *mname;		/* name of the macro 	*/
-    float oscale;		/* scale factor to um, usually 1 */
+LefReadMacro(FILE *f,			/* LEF file being read	*/
+             char *mname,		/* name of the macro 	*/
+             float oscale)		/* scale factor to um, usually 1 */
 {
     GATE lefMacro, altMacro;
     char *token, tsave[128];
@@ -2656,11 +2638,10 @@ enum lef_layer_keys {LEF_LAYER_TYPE=0, LEF_LAYER_WIDTH,
 enum lef_spacing_keys {LEF_SPACING_RANGE=0, LEF_END_LAYER_SPACING};
 
 void
-LefReadLayerSection(f, lname, mode, lefl)
-    FILE *f;			/* LEF file being read	  */
-    char *lname;		/* name of the layer 	  */
-    int mode;			/* layer, via, or viarule */
-    LefList lefl;		/* pointer to layer info  */
+LefReadLayerSection(FILE *f,		/* LEF file being read	  */
+                    char *lname,	/* name of the layer 	  */
+                    int mode,		/* layer, via, or viarule */
+                    LefList lefl)	/* pointer to layer info  */
 {
     char *token, *tp;
     int keyword, typekey = -1, entries, i;
@@ -3672,8 +3653,7 @@ LefAssignLayerVias()
 /* See above for "enum lef_sections {...}" */
 
 int
-LefRead(inName)
-    char *inName;
+LefRead(char *inName)
 {
     FILE *f;
     char filename[256];

--- a/maze.c
+++ b/maze.c
@@ -432,7 +432,7 @@ int set_node_to_net(NODE node, int newflags, POINT *pushlist,
 
 	  rank = 0;
           if (lay < Pinlayers) {
-	     if (lnode = NODEIPTR(x, y, lay)) {
+	     if ((lnode = NODEIPTR(x, y, lay))) {
 		if (lnode->flags & NI_OFFSET_MASK) rank = 2;
 		if (lnode->flags & NI_STUB_MASK) rank++;
 	     }
@@ -1791,9 +1791,7 @@ void writeback_segment(SEG seg, int netnum)
 /*--------------------------------------------------------------*/
 
 void
-route_set_connections(net, route)
-   NET   net;
-   ROUTE route;
+route_set_connections(NET net, ROUTE route)
 {
    SEG      seg, s;
    ROUTE    nr;

--- a/qrouterexec.c
+++ b/qrouterexec.c
@@ -14,8 +14,7 @@
 /*----------------------------------------------------------------------*/
 
 int
-qrouter_AppInit(interp)
-    Tcl_Interp *interp;
+qrouter_AppInit(Tcl_Interp *interp)
 {
     if (Tcl_Init(interp) == TCL_ERROR) {
 	return TCL_ERROR;
@@ -42,9 +41,7 @@ qrouter_AppInit(interp)
 /*----------------------------------------------------------------------*/
 
 int
-main(argc, argv)
-   int argc;
-   char **argv;
+main(int argc, char **argv)
 {
     Tk_Main(argc, argv, qrouter_AppInit);
     return 0;

--- a/tkSimple.c
+++ b/tkSimple.c
@@ -111,12 +111,12 @@ static int		SimpleWidgetObjCmd _ANSI_ARGS_((ClientData clientData,
  */
 
 int
-Tk_SimpleObjCmd(clientData, interp, objc, objv)
-    ClientData clientData;	/* Main window associated with
+Tk_SimpleObjCmd(
+    ClientData clientData,	/* Main window associated with
 				 * interpreter. */
-    Tcl_Interp *interp;		/* Current interpreter. */
-    int objc;			/* Number of arguments. */
-    Tcl_Obj *CONST objv[];	/* Argument objects. */
+    Tcl_Interp *interp,		/* Current interpreter. */
+    int objc,			/* Number of arguments. */
+    Tcl_Obj *CONST objv[])	/* Argument objects. */
 {
     Tk_Window tkwin = (Tk_Window) clientData;
     Simple *simplePtr;
@@ -220,11 +220,11 @@ Tk_SimpleObjCmd(clientData, interp, objc, objv)
  */
 
 static int
-SimpleWidgetObjCmd(clientData, interp, objc, objv)
-    ClientData clientData;	/* Information about simple widget. */
-    Tcl_Interp *interp;		/* Current interpreter. */
-    int objc;			/* Number of arguments. */
-    Tcl_Obj *CONST objv[];	/* Argument objects. */
+SimpleWidgetObjCmd(
+    ClientData clientData,	/* Information about simple widget. */
+    Tcl_Interp *interp,		/* Current interpreter. */
+    int objc,			/* Number of arguments. */
+    Tcl_Obj *CONST objv[])	/* Argument objects. */
 {
     static char *simpleOptions[] = {
 	"cget", "configure", (char *) NULL
@@ -305,8 +305,7 @@ SimpleWidgetObjCmd(clientData, interp, objc, objv)
  */
 
 static void
-DestroySimple(memPtr)
-    char *memPtr;		/* Info about simple widget. */
+DestroySimple(char *memPtr)	/* Info about simple widget. */
 {
     register Simple *simplePtr = (Simple *) memPtr;
 
@@ -341,13 +340,13 @@ DestroySimple(memPtr)
  */
 
 static int
-ConfigureSimple(interp, simplePtr, objc, objv, flags)
-    Tcl_Interp *interp;		/* Used for error reporting. */
-    register Simple *simplePtr;	/* Information about widget;  may or may
+ConfigureSimple(
+    Tcl_Interp *interp,		/* Used for error reporting. */
+    register Simple *simplePtr,	/* Information about widget;  may or may
 				 * not already have values for some fields. */
-    int objc;			/* Number of valid entries in objv. */
-    Tcl_Obj *CONST objv[];	/* Arguments. */
-    int flags;			/* Flags to pass to Tk_ConfigureWidget. */
+    int objc,			/* Number of valid entries in objv. */
+    Tcl_Obj *CONST objv[],	/* Arguments. */
+    int flags)			/* Flags to pass to Tk_ConfigureWidget. */
 {
     
     if (Tk_ConfigureWidget(interp, simplePtr->tkwin, configSpecs,
@@ -385,9 +384,9 @@ ConfigureSimple(interp, simplePtr, objc, objv, flags)
  */
 
 static void
-SimpleEventProc(clientData, eventPtr)
-    ClientData clientData;	/* Information about window. */
-    register XEvent *eventPtr;	/* Information about event. */
+SimpleEventProc(
+    ClientData clientData,	/* Information about window. */
+    register XEvent *eventPtr)	/* Information about event. */
 {
     register Simple *simplePtr = (Simple *) clientData;
 
@@ -451,8 +450,8 @@ SimpleEventProc(clientData, eventPtr)
  */
 
 static void
-SimpleCmdDeletedProc(clientData)
-    ClientData clientData;	/* Pointer to widget record for widget. */
+SimpleCmdDeletedProc(
+    ClientData clientData)	/* Pointer to widget record for widget. */
 {
     Simple *simplePtr = (Simple *) clientData;
     Tk_Window tkwin = simplePtr->tkwin;


### PR DESCRIPTION
Couldn't stand all those "a function definition without a prototype is deprecated in all versions of C and is not support
ed in C23" warnings I get during compilation, so I fixed them :)

Plus on line 1170 of `def.c`, the scanf asks for 2048 chars, but the buffer is only 1024 characters long.