### PR TITLE
qrouter: use worst-case via rotation in apply_drc_blocks()

### DIFF
--- a/qrouter.c
+++ b/qrouter.c
@@ -669,6 +669,10 @@ void apply_drc_blocks(int layer, double via_except, double route_except)
    // different geometries based on the permutation of rotations of
    // the top and bottom layers, so we only register blocking behavior
    // if all of the via types will generate spacing violations.
+   // To honor that worst-case semantics, the VIABLOCK selections below
+   // take the MAXIMUM via width across rotations, so the subsequent
+   // (sreq2 - EPS) > Pitch comparison fires whenever any rotation
+   // would violate the spacing.
 
    for (i = 0; i < Num_layers; i++) {
       if ((layer >= 0) && (i != layer)) continue;
@@ -679,22 +683,22 @@ void apply_drc_blocks(int layer, double via_except, double route_except)
       if (i < Num_layers - 1) {
          sreq2 = LefGetXYViaWidth(i, i, 0, 0) + sreq1;
          sreq2t = LefGetXYViaWidth(i, i, 0, 1) + sreq1;
-         if (sreq2t < sreq2) sreq2 = sreq2t;
+         if (sreq2t > sreq2) sreq2 = sreq2t;
          sreq2t = LefGetXYViaWidth(i, i, 0, 2) + sreq1;
-         if (sreq2t < sreq2) sreq2 = sreq2t;
+         if (sreq2t > sreq2) sreq2 = sreq2t;
          sreq2t = LefGetXYViaWidth(i, i, 0, 3) + sreq1;
-         if (sreq2t < sreq2) sreq2 = sreq2t;
+         if (sreq2t > sreq2) sreq2 = sreq2t;
 	 sreq2 -= via_except;
          if ((sreq2 - EPS) > PitchX) needblock[i] |= VIABLOCKX;
       }
       if (i != 0) {
 	 sreq2 = LefGetXYViaWidth(i - 1, i, 0, 0) + sreq1;
 	 sreq2t = LefGetXYViaWidth(i - 1, i, 0, 1) + sreq1;
-	 if (sreq2t < sreq2) sreq2 = sreq2t;
+	 if (sreq2t > sreq2) sreq2 = sreq2t;
 	 sreq2t = LefGetXYViaWidth(i - 1, i, 0, 2) + sreq1;
-	 if (sreq2t < sreq2) sreq2 = sreq2t;
+	 if (sreq2t > sreq2) sreq2 = sreq2t;
 	 sreq2t = LefGetXYViaWidth(i - 1, i, 0, 3) + sreq1;
-	 if (sreq2t < sreq2) sreq2 = sreq2t;
+	 if (sreq2t > sreq2) sreq2 = sreq2t;
 	 sreq2 -= via_except;
          if ((sreq2 - EPS) > PitchX) needblock[i] |= VIABLOCKX;
       }
@@ -702,22 +706,22 @@ void apply_drc_blocks(int layer, double via_except, double route_except)
       if (i < Num_layers - 1) {
          sreq2 = LefGetXYViaWidth(i, i, 1, 0) + sreq1;
          sreq2t = LefGetXYViaWidth(i, i, 1, 1) + sreq1;
-         if (sreq2t < sreq2) sreq2 = sreq2t;
+         if (sreq2t > sreq2) sreq2 = sreq2t;
          sreq2t = LefGetXYViaWidth(i, i, 1, 2) + sreq1;
-         if (sreq2t < sreq2) sreq2 = sreq2t;
+         if (sreq2t > sreq2) sreq2 = sreq2t;
          sreq2t = LefGetXYViaWidth(i, i, 1, 3) + sreq1;
-         if (sreq2t < sreq2) sreq2 = sreq2t;
+         if (sreq2t > sreq2) sreq2 = sreq2t;
 	 sreq2 -= via_except;
          if ((sreq2 - EPS) > PitchY) needblock[i] |= VIABLOCKY;
       }
       if (i != 0) {
 	 sreq2 = LefGetXYViaWidth(i - 1, i, 1, 0) + sreq1;
 	 sreq2t = LefGetXYViaWidth(i - 1, i, 1, 1) + sreq1;
-	 if (sreq2t < sreq2) sreq2 = sreq2t;
+	 if (sreq2t > sreq2) sreq2 = sreq2t;
 	 sreq2t = LefGetXYViaWidth(i - 1, i, 1, 2) + sreq1;
-	 if (sreq2t < sreq2) sreq2 = sreq2t;
+	 if (sreq2t > sreq2) sreq2 = sreq2t;
 	 sreq2t = LefGetXYViaWidth(i - 1, i, 1, 3) + sreq1;
-	 if (sreq2t < sreq2) sreq2 = sreq2t;
+	 if (sreq2t > sreq2) sreq2 = sreq2t;
 	 sreq2 -= via_except;
          if ((sreq2 - EPS) > PitchY) needblock[i] |= VIABLOCKY;
       }


### PR DESCRIPTION
Hi there,

`apply_drc_blocks()` reduces the up to four rotation variants of each via type into a single representative width before deciding whether to set the VIABLOCK bits for an adjacent track. The comment above the loop states the intended semantics, that blocking is registered only when every rotation would violate spacing, which is a worst-case keep-out selection. The implementation uses if (sreq2t < sreq2) sreq2 = sreq2t; across the three pairwise reductions and so picks the MINIMUM via width. The legal rotation then masks the larger rotation, the router places the offending via on the next track, and because qrouter performs no post-route geometric DRC the spacing violation ships in the DEF.

On sky130 high density metal1-to-metal2 vias the un-rotated case leaves 0.14 um (legal) and the rotated case leaves 0.11 um (a 0.03 um violation). An adversary authoring a hard macro can choose a placement that the global router will reach with the rotated via and the resulting short is invisible to qrouter. Flipping the twelve comparisons across the four VIABLOCK blocks (three per block) from < to > makes the running variable hold the maximum via width, so the (sreq2 - EPS) > Pitch test becomes the worst-case check the comment already promised.

Thanks!
Flavien